### PR TITLE
Auto-confirm apt-add-repository

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -30,7 +30,7 @@ echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
 # Install Docker
 sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" -y
 sudo apt update
 sudo apt install docker-ce -y
 


### PR DESCRIPTION
When running `deploy.sh`, the script currently pauses and waits for the user to press Enter due to `apt-add-repository` command being used without the -y flag.

This PR adds the -y flag to automatically confirm and proceed.

Example:
```
Repository: 'deb [arch=amd64] https://download.docker.com/linux/ubuntu noble stable'
Description:
Archive for codename: noble components: stable
More info: https://download.docker.com/linux/ubuntu
Adding repository.
Press [ENTER] to continue or Ctrl-c to cancel.
```