### PR TITLE
deploy.sh allow non root with sudo to execute and zero down time on update.sh (kinda) 

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -111,7 +111,7 @@ if [ ! -f /etc/letsencrypt/ssl-dhparams.pem ]; then
 fi
 
 # Create Nginx config with reverse proxy, SSL support, rate limiting, and streaming support
-sudo cat > /etc/nginx/sites-available/myapp <<EOL
+sudo tee /etc/nginx/sites-available/myapp > /dev/null <<EOL
 limit_req_zone \$binary_remote_addr zone=mylimit:10m rate=10r/s;
 
 server {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   web:
     build: .
+    container_name: myapp_web
     ports:
       - '3000:3000'
     environment:

--- a/update.sh
+++ b/update.sh
@@ -15,10 +15,32 @@ else
   cd $APP_DIR
 fi
 
-# Build and restart the Docker containers from the app directory (~/myapp)
-echo "Rebuilding and restarting Docker containers..."
-sudo docker-compose down
-sudo docker-compose up --build -d
+# Build the new image
+echo "Building new Docker image..."
+sudo docker-compose build
+
+# Check if the build was successful
+if [ $? -ne 0 ]; then
+  echo "Docker build failed. Aborting deployment."
+  exit 1
+fi
+
+# Start the new containers without stopping the old ones
+echo "Starting new containers..."
+sudo docker-compose up -d --no-deps --scale web=2 --no-recreate
+
+# Wait for the new container to be healthy (adjust the health check as needed)
+echo "Waiting for new container to be ready..."
+sleep 10  # Adjust this value based on your application's startup time
+
+# Stop and remove the old container
+echo "Stopping old container..."
+OLD_CONTAINER=$(sudo docker-compose ps -q web | head -n 1)
+sudo docker stop $OLD_CONTAINER
+sudo docker rm $OLD_CONTAINER
+
+# Scale back to one instance
+sudo docker-compose up -d --no-deps --scale web=1 --no-recreate
 
 # Check if Docker Compose started correctly
 if ! sudo docker-compose ps | grep "Up"; then


### PR DESCRIPTION
thanks for the tutorial lee!
on previous commit, this script shows how to deploy using root user, but for some cases we want to disable root login and give another user sudo privileges to do deployment, i logged in with custom user and with previous command it will throw error like 'permission denied', this update works on my deployment.
also when updating, update.sh take the docker image down first then building the new one, which there will be no running website during building new image, updated update.sh will have zero down time deploymen (kinda) and if new container is fail,  it will exit without taking the old image down *sorrybadenglish:v